### PR TITLE
Remove django-debugtoolsbar from settings.py.

### DIFF
--- a/iris/core/settings.py
+++ b/iris/core/settings.py
@@ -27,7 +27,6 @@ except ImportError:
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
-INTERNAL_IPS = ('127.0.0.1', 'localhost')
 
 SQLITE_DB_FILE = path.join(path.expanduser('~'), '.cache', 'iris.db')
 
@@ -291,11 +290,6 @@ if 'test' in argv:
 
     TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS\
         + ("django.core.context_processors.request",)
-
-if DEBUG:
-    INSTALLED_APPS += (
-        'debug_toolbar',
-    )
 
 """
 If you want to log the number of sql queries, you can use LogSQLPanel


### PR DESCRIPTION
We don't install this package on server, however sometime when we
need to temporarily enable DEBUG on server, this setting will raise
exception.

If someone wants to use this debugtoolbar, he/she can add it in
local /etc/iris/iris.conf file.

Change-Id: Ie6b5c3fd426f21732156a03c75e465dac114e9a9