### PR TITLE
Make "gittrees" not required when creating new product

### DIFF
--- a/iris/core/models/packagedb.py
+++ b/iris/core/models/packagedb.py
@@ -198,7 +198,7 @@ class Product(models.Model):
 
     name = models.CharField(max_length=255, unique=True)
     description = models.TextField()
-    gittrees = models.ManyToManyField(GitTree)
+    gittrees = models.ManyToManyField(GitTree, blank=True)
 
     def __unicode__(self):
         return self.name


### PR DESCRIPTION
As default, when creating new product in admin page, it requires to
select gittrees, however this is not necessary.